### PR TITLE
add per-answer "complete" and "incorrect" callbacks, and tweak crossword-level

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -66,6 +66,15 @@
       "contributions": [
         "ideas"
       ]
+    },
+    {
+      "login": "HuHguZ",
+      "name": "Ilya Lukyanov",
+      "avatar_url": "https://avatars.githubusercontent.com/u/32592443?v=4",
+      "profile": "https://github.com/HuHguZ",
+      "contributions": [
+        "ideas"
+      ]
     }
   ]
 }

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -5,6 +5,7 @@ extends:
   - airbnb
   - plugin:react/recommended
   - plugin:react/jsx-runtime
+  - plugin:react-hooks/recommended
   - plugin:@typescript-eslint/recommended
   - prettier
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![more badges](https://img.shields.io/badge/badges-%F0%9F%91%8D%20are%20fun-orange)
 [![commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![contributors](https://img.shields.io/badge/contributors-6-orange.svg)](#contributors-)
+[![contributors](https://img.shields.io/badge/contributors-7-orange.svg)](#contributors-)
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -162,6 +162,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://www.soindaial.com.br/"><img src="https://avatars.githubusercontent.com/u/42916864?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Albranco</b></sub></a><br /><a href="#ideas-drero" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://www.robmccollough.dev/"><img src="https://avatars.githubusercontent.com/u/42196611?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rob McCollough</b></sub></a><br /><a href="#ideas-robmccollough" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://github.com/lorddaedra"><img src="https://avatars.githubusercontent.com/u/26400787?v=4?s=100" width="100px;" alt=""/><br /><sub><b>lorddaedra</b></sub></a><br /><a href="#ideas-lorddaedra" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/HuHguZ"><img src="https://avatars.githubusercontent.com/u/32592443?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ilya Lukyanov</b></sub></a><br /><a href="#ideas-HuHguZ" title="Ideas, Planning, & Feedback">🤔</a></td>
   </tr>
 </table>
 

--- a/src/Clue.tsx
+++ b/src/Clue.tsx
@@ -6,13 +6,16 @@ import type { Direction, EnhancedProps } from './types';
 import { CrosswordContext } from './context';
 
 interface ClueWrapperProps {
+  complete?: boolean | null;
   correct?: boolean | null;
   highlight?: boolean | null;
   highlightBackground?: string | null;
 }
 
 const ClueWrapper = styled.div.attrs<ClueWrapperProps>((props) => ({
-  className: `clue${props.correct ? ' correct' : ''}`,
+  className: `clue${
+    props.complete ? (props.correct ? ' correct' : ' incorrect') : ''
+  }`,
 }))<ClueWrapperProps>`
   cursor: default;
   background-color: ${(props) =>
@@ -28,6 +31,7 @@ export default function Clue({
   direction,
   number,
   children,
+  complete,
   correct,
   ...props
 }: EnhancedProps<
@@ -55,6 +59,7 @@ export default function Clue({
       highlight={
         focused && direction === selectedDirection && number === selectedNumber
       }
+      complete={complete}
       correct={correct}
       {...props}
       onClick={handleClick}
@@ -72,11 +77,14 @@ Clue.propTypes = {
   number: PropTypes.string.isRequired,
   /** clue text */
   children: PropTypes.node.isRequired,
+  /** whether the answer/guess is complete */
+  complete: PropTypes.bool,
   /** whether the answer/guess is correct */
   correct: PropTypes.bool,
 };
 
 Clue.defaultProps = {
   // children: undefined,
+  complete: undefined,
   correct: undefined,
 };

--- a/src/CrosswordGrid.tsx
+++ b/src/CrosswordGrid.tsx
@@ -171,7 +171,7 @@ export default function CrosswordGrid({ theme }: CrosswordGridProps) {
   // order in Javascript, of course.)
   const finalTheme = useMemo(
     () => ({ ...defaultTheme, ...contextTheme, ...theme }),
-    [defaultTheme, contextTheme, theme]
+    [contextTheme, theme]
   );
 
   return (

--- a/src/DirectionClues.tsx
+++ b/src/DirectionClues.tsx
@@ -36,11 +36,12 @@ export default function DirectionClues({
     <div className="direction">
       {/* use something other than h3? */}
       <h3 className="header">{label || direction.toUpperCase()}</h3>
-      {clues?.[direction].map(({ number, clue, correct }) => (
+      {clues?.[direction].map(({ number, clue, complete, correct }) => (
         <Clue
           key={number}
           direction={direction}
           number={number}
+          complete={complete}
           correct={correct}
         >
           {clue}

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,11 @@ export type GridData = CellData[][];
 
 export type CluesData = Record<
   Direction,
-  (ClueTypeOriginal & { number: string; correct?: boolean })[]
+  (ClueTypeOriginal & {
+    number: string;
+    complete?: boolean;
+    correct?: boolean;
+  })[]
 >;
 
 export type AnswerTuple = [Direction, string, string];


### PR DESCRIPTION

_(slight mis-type in feature commit... it's per-answer "incorrect" not "incomplete"!)_

To supplement the existing `onCorrect` callback, new `onAnswerComplete`, `onAnswerCorrect` and
`onAnswerIncorrect` callbacks have been added.  (`onAnswerCorrect` is 100% the same as `onCorrect`;
I'm changing the name for clarity, and will deprecate `onCorrect` in the future.)  Also, a
crossword-level `onCrosswordComplete` has been added.