### PR TITLE
feat: expose CrosswordSizeContext & Provider

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -49,8 +49,14 @@ export default function Cell({
   focus,
   highlight,
 }: CellProps) {
-  const { cellSize, cellPadding, cellInner, cellHalf, fontSize } =
-    useContext(CrosswordSizeContext);
+  const {
+    cellSize,
+    cellPadding,
+    cellInner,
+    cellHalf,
+    cellTextVerticalOffset,
+    fontSize,
+  } = useContext(CrosswordSizeContext);
   const {
     // gridBackground,
     cellBackground,
@@ -110,7 +116,7 @@ export default function Cell({
       )}
       <text
         x={x + cellHalf}
-        y={y + cellHalf + 1} // +1 for visual alignment?
+        y={y + cellHalf + cellTextVerticalOffset}
         textAnchor="middle"
         dominantBaseline="middle"
         style={{ fill: textColor }}

--- a/src/CrosswordGrid.tsx
+++ b/src/CrosswordGrid.tsx
@@ -130,12 +130,25 @@ export default function CrosswordGrid({ theme }: CrosswordGridProps) {
   const cellPadding = 0.125;
   const cellInner = cellSize - cellPadding * 2;
   const cellHalf = cellSize / 2;
+  const cellTextVerticalOffset = 1; // +1 for visual alignment?
   const fontSize = cellInner * 0.7;
 
-  const sizeContext = useMemo(
-    () => ({ cellSize, cellPadding, cellInner, cellHalf, fontSize }),
-    [cellSize, cellPadding, cellInner, cellHalf, fontSize]
-  );
+  const contextSize = useContext(CrosswordSizeContext);
+
+  // The final size is the merger of two values: any values from an outer
+  // CrosswordSizeContext.Provider, then the "defaultSize" values fill in for any
+  // needed ones that are missing.
+  const finalSize = useMemo(() => {
+    const defaultSize = {
+      cellSize,
+      cellPadding,
+      cellInner,
+      cellHalf,
+      cellTextVerticalOffset,
+      fontSize,
+    };
+    return { ...defaultSize, ...contextSize };
+  }, [cellSize, cellInner, cellHalf, fontSize, contextSize]);
 
   const inputStyle = useMemo(
     () =>
@@ -175,7 +188,7 @@ export default function CrosswordGrid({ theme }: CrosswordGridProps) {
   );
 
   return (
-    <CrosswordSizeContext.Provider value={sizeContext}>
+    <CrosswordSizeContext.Provider value={finalSize}>
       <ThemeProvider theme={finalTheme}>
         <GridWrapper>
           {/*

--- a/src/__test__/Cell.test.tsx
+++ b/src/__test__/Cell.test.tsx
@@ -28,6 +28,7 @@ const sizeContext = {
   cellPadding: 1,
   cellInner: 8,
   cellHalf: 4,
+  cellTextVerticalOffset: 1,
   fontSize: 7,
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -46,7 +46,7 @@ export interface CrosswordContextType {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-function nop() {}
+function nop() { }
 
 /**
  * CrosswordContext represents the crossword puzzle itself, as well as provides
@@ -75,18 +75,13 @@ export const CrosswordContext = React.createContext<CrosswordContextType>({
 });
 
 export interface CrosswordSizeContextType {
-  cellSize: number;
-  cellPadding: number;
-  cellInner: number;
-  cellHalf: number;
-  fontSize: number;
+  cellSize?: number;
+  cellPadding?: number;
+  cellInner?: number;
+  cellHalf?: number;
+  cellTextVerticalOffset?: number;
+  fontSize?: number;
 }
 
 export const CrosswordSizeContext =
-  React.createContext<CrosswordSizeContextType>({
-    cellSize: 0,
-    cellPadding: 0,
-    cellInner: 0,
-    cellHalf: 0,
-    fontSize: 0,
-  });
+  React.createContext<CrosswordSizeContextType>({});


### PR DESCRIPTION
Enables users to modify CrosswordSizeContext via its associated
Provider. All previous default values remain unchanged for backwards
compatibility.

Also makes cellTextVerticalOffset a configurable parameter of
CrosswordSizeContext. This vertical offset was previously hardcoded to
`1` which displayed text awkwardly low in larger grids (e.g. 40x40). A
user can now override this default to `0` to keep text vertically
centered in smaller cells.