### PR TITLE
feat: Update navigation for Tab, Enter, and Space keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -13647,9 +13647,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -23322,9 +23322,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "dev": true
         },
         "semver": {
@@ -33446,9 +33446,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/src/CrosswordProvider.tsx
+++ b/src/CrosswordProvider.tsx
@@ -703,19 +703,42 @@ const CrosswordProvider = React.forwardRef<
             moveRelative(0, 1);
             break;
 
-          case ' ': // treat space like tab?
+          // move to the next/last entry, switching directions if necessary
+          case 'Enter':
           case 'Tab': {
-            const other = otherDirection(currentDirection);
-            const cellData = getCellData(
-              focusedRow,
-              focusedCol
-            ) as UsedCellData;
-            if (cellData[other]) {
-              setCurrentDirection(other);
-              setCurrentNumber(cellData[other] ?? '');
+            if (!clues) break;
+
+            const delta = event.shiftKey ? -1 : 1;
+            const nextClueIndex =
+              clues[currentDirection].findIndex(
+                (clue) => clue.number === currentNumber
+              ) + delta;
+            let nextClue;
+
+            if (
+              nextClueIndex >= clues[currentDirection].length ||
+              nextClueIndex === -1
+            ) {
+              const otherDirIndex = event.shiftKey
+                ? clues[otherDirection(currentDirection)].length - 1
+                : 0;
+              nextClue = clues[otherDirection(currentDirection)][otherDirIndex];
+              moveTo(
+                nextClue.row,
+                nextClue.col,
+                otherDirection(currentDirection)
+              );
+            } else {
+              nextClue = clues[currentDirection][nextClueIndex];
+              moveTo(nextClue.row, nextClue.col);
             }
+
             break;
           }
+
+          case ' ':
+            moveForward();
+            break;
 
           // Backspace: delete the current cell, and move to the previous cell
           // Delete:    delete the current cell, but don't move
@@ -775,7 +798,9 @@ const CrosswordProvider = React.forwardRef<
         focusedCol,
         setCellCharacter,
         moveBackward,
+        moveForward,
         data,
+        clues,
         currentNumber,
         moveTo,
       ]

--- a/src/__test__/CrosswordProvider.test.tsx
+++ b/src/__test__/CrosswordProvider.test.tsx
@@ -165,24 +165,39 @@ describe('keyboard navigation', () => {
     expect(y).toBe('20.125');
   });
 
-  it('tab switches direction (across to down)', async () => {
+  it('tab navigates to next clue (across-across)', async () => {
     const { getByLabelText, getByText, user } = setup(
       <Size4 withGrid withClues />
     );
     const input = getByLabelText('crossword-input');
 
     await user.click(getByLabelText('clue-1-across'));
-    fireEvent.keyDown(input, { key: 'End' });
 
-    fireEvent.keyDown(input, { key: 'Tab' }); // switches to 2-down
-    fireEvent.keyDown(input, { key: 'End' });
+    fireEvent.keyDown(input, { key: 'Tab' }); // switches to 3-across
     fireEvent.keyDown(input, { key: 'X' });
+
     const { x, y } = posForText(getByText('X'));
     expect(x).toBe('20.125');
-    expect(y).toBe('20.125');
+    expect(y).toBe('10.125');
   });
 
-  it('tab switches direction (down to across)', async () => {
+  it('tab navigates to previous clue (across-down)', async () => {
+    const { getByLabelText, getByText, user } = setup(
+      <Size4 withGrid withClues />
+    );
+    const input = getByLabelText('crossword-input');
+
+    await user.click(getByLabelText('clue-1-across'));
+
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true }); // switches to 2-down
+    fireEvent.keyDown(input, { key: 'X' });
+
+    const { x, y } = posForText(getByText('X'));
+    expect(x).toBe('20.125');
+    expect(y).toBe('0.125');
+  });
+
+  it('tab navigates to next clue (down-across)', async () => {
     const { getByLabelText, getByText, user } = setup(
       <Size4 withGrid withClues />
     );
@@ -191,31 +206,46 @@ describe('keyboard navigation', () => {
     await user.click(getByLabelText('clue-2-down'));
 
     fireEvent.keyDown(input, { key: 'Tab' }); // switches to 1-across
-    fireEvent.keyDown(input, { key: 'Home' });
     fireEvent.keyDown(input, { key: 'X' });
+
     const { x, y } = posForText(getByText('X'));
     expect(x).toBe('0.125');
     expect(y).toBe('0.125');
   });
 
-  it('space switches direction (across to down)', async () => {
+  it('enter navigates to next clue (across-across)', async () => {
     const { getByLabelText, getByText, user } = setup(
       <Size4 withGrid withClues />
     );
     const input = getByLabelText('crossword-input');
 
     await user.click(getByLabelText('clue-1-across'));
-    fireEvent.keyDown(input, { key: 'End' });
 
-    fireEvent.keyDown(input, { key: ' ' }); // switches to 2-down
-    fireEvent.keyDown(input, { key: 'End' });
+    fireEvent.keyDown(input, { key: 'Enter' }); // switches to 3-across
     fireEvent.keyDown(input, { key: 'X' });
+
     const { x, y } = posForText(getByText('X'));
     expect(x).toBe('20.125');
-    expect(y).toBe('20.125');
+    expect(y).toBe('10.125');
   });
 
-  it('space switches direction (down to across)', async () => {
+  it('shift-enter navigates to previous clue (across-down)', async () => {
+    const { getByLabelText, getByText, user } = setup(
+      <Size4 withGrid withClues />
+    );
+    const input = getByLabelText('crossword-input');
+
+    await user.click(getByLabelText('clue-1-across'));
+
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true }); // switches to 2-down
+    fireEvent.keyDown(input, { key: 'X' });
+
+    const { x, y } = posForText(getByText('X'));
+    expect(x).toBe('20.125');
+    expect(y).toBe('0.125');
+  });
+
+  it('enter navigates to next clue (down-across)', async () => {
     const { getByLabelText, getByText, user } = setup(
       <Size4 withGrid withClues />
     );
@@ -223,11 +253,27 @@ describe('keyboard navigation', () => {
 
     await user.click(getByLabelText('clue-2-down'));
 
-    fireEvent.keyDown(input, { key: ' ' }); // switches to 1-across
-    fireEvent.keyDown(input, { key: 'Home' });
+    fireEvent.keyDown(input, { key: 'Enter' }); // switches to 1-across
     fireEvent.keyDown(input, { key: 'X' });
+
     const { x, y } = posForText(getByText('X'));
     expect(x).toBe('0.125');
+    expect(y).toBe('0.125');
+  });
+
+  it('space navigates forward', async () => {
+    const { getByLabelText, getByText, user } = setup(
+      <Size4 withGrid withClues />
+    );
+    const input = getByLabelText('crossword-input');
+
+    await user.click(getByLabelText('clue-1-across'));
+
+    fireEvent.keyDown(input, { key: ' ' }); // switches to 2-down
+    fireEvent.keyDown(input, { key: 'X' });
+
+    const { x, y } = posForText(getByText('X'));
+    expect(x).toBe('10.125');
     expect(y).toBe('0.125');
   });
 


### PR DESCRIPTION
This PR updates navigation for Tab, Enter, and Space.

Tab/Enter will navigate to the next clue. Shift-Tab or Shift-Enter will navigate to the previous clue. Space will move forward one square.

I tried to more closely model what the NYT puzzle does. Let me know what you think!