### PR TITLE
prevent overwriting stored guesses in StrictMode

### DIFF
--- a/src/CrosswordProvider.tsx
+++ b/src/CrosswordProvider.tsx
@@ -851,7 +851,7 @@ const CrosswordProvider = React.forwardRef<
 
     // save the guesses any time they change...
     useEffect(() => {
-      if (gridData === null || !useStorage) {
+      if (gridData === null || gridData.length === 0 || !useStorage) {
         return;
       }
 


### PR DESCRIPTION
Check for empty gridData to prevent overwriting stored guesses in React.StrictMode